### PR TITLE
add extra encounter data

### DIFF
--- a/hasura/metadata/databases/default/tables/public_encounter_environments.yaml
+++ b/hasura/metadata/databases/default/tables/public_encounter_environments.yaml
@@ -1,0 +1,23 @@
+table:
+  name: encounter_environments
+  schema: public
+is_enum: true
+array_relationships:
+- name: encounters
+  using:
+    foreign_key_constraint_on:
+      column: environment
+      table:
+        name: encounters
+        schema: public
+select_permissions:
+- permission:
+    columns:
+    - encounter_environment
+    filter: {}
+  role: anonymous
+- permission:
+    columns:
+    - encounter_environment
+    filter: {}
+  role: user

--- a/hasura/metadata/databases/default/tables/public_encounters.yaml
+++ b/hasura/metadata/databases/default/tables/public_encounters.yaml
@@ -5,6 +5,9 @@ object_relationships:
 - name: encounterTypeByEncounterType
   using:
     foreign_key_constraint_on: encounter_type
+- name: encounter_environment
+  using:
+    foreign_key_constraint_on: environment
 - name: reward
   using:
     foreign_key_constraint_on: reward_id
@@ -61,37 +64,43 @@ array_relationships:
 select_permissions:
 - permission:
     columns:
-    - active
-    - created_at
-    - description
-    - encounter_type
-    - energy_cost
     - id
-    - image
-    - loss_text
-    - max_rats
-    - name
+    - energy_cost
     - power
-    - reward_id
-    - updated_at
+    - name
+    - description
     - win_text
+    - loss_text
+    - image
+    - active
+    - encounter_type
+    - created_at
+    - updated_at
+    - reward_id
+    - max_rats
+    - success_image
+    - fail_image
+    - environment
     filter: {}
   role: anonymous
 - permission:
     columns:
     - active
-    - created_at
-    - description
-    - encounter_type
     - energy_cost
     - id
-    - image
-    - loss_text
     - max_rats
-    - name
     - power
     - reward_id
-    - updated_at
+    - description
+    - encounter_type
+    - environment
+    - fail_image
+    - image
+    - loss_text
+    - name
+    - success_image
     - win_text
+    - created_at
+    - updated_at
     filter: {}
   role: user

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -1,5 +1,6 @@
 - "!include public_closet_pieces.yaml"
 - "!include public_closet_tokens.yaml"
+- "!include public_encounter_environments.yaml"
 - "!include public_encounter_rat_constraints.yaml"
 - "!include public_encounter_resistance.yaml"
 - "!include public_encounter_types.yaml"

--- a/hasura/migrations/default/1645671754413_alter_table_public_encounters_add_column_success_image/down.sql
+++ b/hasura/migrations/default/1645671754413_alter_table_public_encounters_add_column_success_image/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."encounters" add column "success_image" text
+--  null;

--- a/hasura/migrations/default/1645671754413_alter_table_public_encounters_add_column_success_image/up.sql
+++ b/hasura/migrations/default/1645671754413_alter_table_public_encounters_add_column_success_image/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."encounters" add column "success_image" text
+ null;

--- a/hasura/migrations/default/1645671761302_alter_table_public_encounters_add_column_fail_image/down.sql
+++ b/hasura/migrations/default/1645671761302_alter_table_public_encounters_add_column_fail_image/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."encounters" add column "fail_image" text
+--  null;

--- a/hasura/migrations/default/1645671761302_alter_table_public_encounters_add_column_fail_image/up.sql
+++ b/hasura/migrations/default/1645671761302_alter_table_public_encounters_add_column_fail_image/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."encounters" add column "fail_image" text
+ null;

--- a/hasura/migrations/default/1645672247697_create_table_public_encounter_environments/down.sql
+++ b/hasura/migrations/default/1645672247697_create_table_public_encounter_environments/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."encounter_environments";

--- a/hasura/migrations/default/1645672247697_create_table_public_encounter_environments/up.sql
+++ b/hasura/migrations/default/1645672247697_create_table_public_encounter_environments/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE "public"."encounter_environments" ("encounter_environment" text NOT NULL, PRIMARY KEY ("encounter_environment") );

--- a/hasura/migrations/default/1645672260411_insert_into_public_encounter_environments/down.sql
+++ b/hasura/migrations/default/1645672260411_insert_into_public_encounter_environments/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."encounter_environments" WHERE "encounter_environment" = 'sewer';

--- a/hasura/migrations/default/1645672260411_insert_into_public_encounter_environments/up.sql
+++ b/hasura/migrations/default/1645672260411_insert_into_public_encounter_environments/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."encounter_environments"("encounter_environment") VALUES (E'sewer');

--- a/hasura/migrations/default/1645672290842_alter_table_public_encounters_add_column_environment/down.sql
+++ b/hasura/migrations/default/1645672290842_alter_table_public_encounters_add_column_environment/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."encounters" add column "environment" text
+--  null;

--- a/hasura/migrations/default/1645672290842_alter_table_public_encounters_add_column_environment/up.sql
+++ b/hasura/migrations/default/1645672290842_alter_table_public_encounters_add_column_environment/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."encounters" add column "environment" text
+ null;

--- a/hasura/migrations/default/1645672309092_set_fk_public_encounters_environment/down.sql
+++ b/hasura/migrations/default/1645672309092_set_fk_public_encounters_environment/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."encounters" drop constraint "encounters_environment_fkey";

--- a/hasura/migrations/default/1645672309092_set_fk_public_encounters_environment/up.sql
+++ b/hasura/migrations/default/1645672309092_set_fk_public_encounters_environment/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."encounters"
+  add constraint "encounters_environment_fkey"
+  foreign key ("environment")
+  references "public"."encounter_environments"
+  ("encounter_environment") on update no action on delete no action;


### PR DESCRIPTION
- 👷 Added deploy scripts
- Made some changes to the hasura config to fix deployments
- Fixed type in workflow
- 🌱 Added local seed
- added new tables for weakness and resistance
- Added token cache schema
- Added cron job to clear closet_tokens with 0 amounts
- Adjusted default vals for the rats table
- Added attempt_solo_encounter action, added default vals for players
- Added roles and users_roles table to handle RBAC
- adjusted closet-tokens-fkey
- Added rat type to rats table
- fixed rat type column permissions
- Added UpsertPlayer return types to login action
- Fixed admin address
- Fixed migrations and actions
- Added reset_energy SQL function as mutation, added cron job at midnight
- Adjusted solo encounter attempt for xp tracking
- Fixed fkey constraint on resistances and weaknesses
- Added permissions for aggregation on closet and rats
- Added support for using external contracts as constraints in encounters
- Added computed field for sorting closet pieces
- Added auth-check action
- Added success and fail images and encounter environment enum
